### PR TITLE
Update anchore-syft.yml

### DIFF
--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -19,20 +19,31 @@ on:
 
 permissions:
   contents: write
-
+  artifacts: write # Required to upload artifacts
+  
 jobs:
   Anchore-Build-Scan:
     permissions:
       contents: write # required to upload to the Dependency submission API
+      artifacts: write # Required to upload artifacts
+      
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
       uses: actions/checkout@v4
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag localbuild/testimage:latest
+      
     - name: Scan the image and upload dependency results
+      id: sbom_scan
       uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a
       with:
         image: "localbuild/testimage:latest"
         artifact-name: image.spdx.json
         dependency-snapshot: true
+
+    - name: Upload SBOM artifact
+      uses: actions/upload-artifact@v4
+      with:
+          name: sbom
+          path: image.spdx.json


### PR DESCRIPTION
Revised the code to address the artifact deprecation warning "The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "image.spdx.json". Please update your workflow to use v4 of the artifact actions. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/"