### PR TITLE
Update anchore-syft.yml

### DIFF
--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -30,10 +30,10 @@ jobs:
     - name: List SBOM Output Directory
       run: |
         echo "Contents of the SBOM action output directory:"
-        ls -al /tmp/sbom-action-OGhrNU || true
+        ls -al /tmp/sbom-action-* || true
 
     - name: Upload SBOM artifact
       uses: actions/upload-artifact@v4
       with:
         name: sbom
-        path: /tmp/sbom-action-OGhrNU/image.spdx.json # Ensure this is the correct path
+        path: /tmp/sbom-action-*/image.spdx.json # Use wildcard to match the dynamic directory


### PR DESCRIPTION
Fixes for the image file upload issue:
Wildcard in Upload Path: The path in the upload step now uses a wildcard (/tmp/sbom-action-*/image.spdx.json). This allows it to dynamically match the temporary directory created by the anchore/sbom-action.

List Command with Wildcard: The list command will show the contents of the temporary directory that is created for the current run.