### PR TITLE
Update anchore-syft.yml

### DIFF
--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Scan the image and upload dependency results
       id: sbom_scan
-      uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a
+      uses: anchore/sbom-action@latest # update to the latest version
       with:
         image: "localbuild/testimage:latest"
         artifact-name: image.spdx.json


### PR DESCRIPTION
Updated line 24 from "uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a" to "uses: anchore/sbom-action@latest" to address the deprecation warning.